### PR TITLE
feat: mejorar autenticación y documentación de API

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -10,6 +10,7 @@ import {
 import {
   ApiTags,
   ApiOperation,
+  ApiBody,
   ApiResponse,
   ApiBearerAuth,
 } from '@nestjs/swagger';
@@ -27,9 +28,36 @@ export class AuthController {
   @UseGuards(LocalAuthGuard)
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Iniciar sesión' })
-  @ApiResponse({ status: 200, description: 'Login exitoso' })
-  @ApiResponse({ status: 401, description: 'Credenciales inválidas' })
-  async login(@Request() req: any) {
+  @ApiBody({ type: LoginDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Login exitoso',
+    schema: {
+      example: {
+        access_token: 'jwt_token_here',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description:
+      'No autorizado (credenciales inválidas o usuario inactivo/bloqueado)',
+    schema: {
+      oneOf: [
+        {
+          example: {
+            message: 'Credenciales inválidas',
+          },
+        },
+        {
+          example: {
+            message: 'Usuario inactivo o bloqueado',
+          },
+        },
+      ],
+    },
+  })
+  async login(@Request() req: any, @Body() _loginDto: LoginDto) {
     return this.authService.login(req.user);
   }
 
@@ -38,7 +66,24 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Refrescar token' })
   @ApiBearerAuth()
-  @ApiResponse({ status: 200, description: 'Token refrescado exitosamente' })
+  @ApiResponse({
+    status: 200,
+    description: 'Token refrescado exitosamente',
+    schema: {
+      example: {
+        access_token: 'new_jwt_token_here',
+      },
+    },
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'No autorizado',
+    schema: {
+      example: {
+        message: 'No autorizado',
+      },
+    },
+  })
   async refreshToken(@Request() req: any) {
     return this.authService.refreshToken(req.user.id);
   }

--- a/src/modules/auth/strategies/local.strategy.ts
+++ b/src/modules/auth/strategies/local.strategy.ts
@@ -2,6 +2,7 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
 import { UserService } from '../../user/user.service';
+import { UserStatus } from '../../user/entities/user.entity';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
@@ -17,7 +18,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     if (!user) {
       throw new UnauthorizedException('Credenciales inválidas');
     }
-    if (user.status !== 'activo') {
+    if (user.status !== UserStatus.ACTIVO) {
       throw new UnauthorizedException('Usuario inactivo o bloqueado');
     }
     return {

--- a/src/modules/auth/swagger-auth.md
+++ b/src/modules/auth/swagger-auth.md
@@ -1,0 +1,54 @@
+# Autenticación
+
+## Iniciar sesión
+
+Endpoint para autenticar un usuario y obtener un token de acceso.
+
+**URL**: `/auth/login`  
+**Método**: `POST`  
+**Autenticación requerida**: No  
+
+### Parámetros de petición
+
+| Nombre | Tipo | Descripción | Requerido |
+|--------|------|-------------|-----------|
+| username | string | Nombre de usuario o email | Sí |
+| password | string | Contraseña (mínimo 6 caracteres) | Sí |
+
+### Cuerpo de la petición
+
+```json
+{
+  "username": "juan_perez",
+  "password": "password123"
+}
+```
+
+### Respuestas
+
+| Código | Descripción | Contenido |
+|--------|-------------|-----------|
+| 200 | Login exitoso | `{ "access_token": "jwt_token_here" }` |
+| 401 | Credenciales inválidas | `{ "message": "Credenciales inválidas" }` |
+| 401 | Usuario inactivo o bloqueado | `{ "message": "Usuario inactivo o bloqueado" }` |
+
+## Refrescar token
+
+Endpoint para obtener un nuevo token de acceso usando el token actual.
+
+**URL**: `/auth/refresh`  
+**Método**: `POST`  
+**Autenticación requerida**: Sí (Bearer Token)
+
+### Headers
+
+| Nombre | Valor | Descripción |
+|--------|-------|-------------|
+| Authorization | `Bearer <token>` | Token de acceso válido |
+
+### Respuestas
+
+| Código | Descripción | Contenido |
+|--------|-------------|-----------|
+| 200 | Token refrescado exitosamente | `{ "access_token": "new_jwt_token_here" }` |
+| 401 | No autorizado | `{ "message": "No autorizado" }` |

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -163,7 +163,7 @@ export class UserService {
     password: string,
   ): Promise<User | null> {
     const user = await this.userRepository.findOne({
-      where: { username },
+      where: [{ username }, { email: username }],
       relations: ['rol'],
     });
     if (!user) {


### PR DESCRIPTION
- Se agregó el esquema de respuesta en el controlador de autenticación para el inicio de sesión y refresco de token.
- Se implementó la validación del estado del usuario utilizando UserStatus en la estrategia local.
- Se creó un nuevo archivo de documentación Swagger para los endpoints de autenticación.
- Se modificó la búsqueda de usuario para permitir la autenticación por nombre de usuario o correo electrónico.