### PR TITLE
feat(hu): HU-B01/B02/B03 propietarios y mascotas

### DIFF
--- a/docs/HU-B01-B03-propietarios-mascotas.md
+++ b/docs/HU-B01-B03-propietarios-mascotas.md
@@ -1,0 +1,152 @@
+# HU-B01 / HU-B02 / HU-B03 (Backend) - Propietarios y Mascotas
+
+Fecha: 2026-05-14
+Rama: `toro-hu-completas`
+
+Este documento resume lo implementado para que frontend y el resto del equipo sepan:
+1) endpoints y contratos actuales,
+2) validaciones y códigos de estado,
+3) cambios relevantes sobre el modelo en BD.
+
+## Autenticacion
+
+Los endpoints de `propietarios` y `mascotas` requieren JWT.
+
+1. Login (seed por defecto en desarrollo):
+   - `POST /auth/login`
+   - Body:
+     ```json
+     { "username": "admin@pethealth.com", "password": "Admin123!" }
+     ```
+   - Respuesta:
+     ```json
+     { "access_token": "<jwt>" }
+     ```
+2. En requests posteriores:
+   - Header: `Authorization: Bearer <jwt>`
+
+## HU-B01 - Crear propietario (POST /propietarios)
+
+Endpoint:
+- `POST /propietarios`
+
+Roles permitidos:
+- `admin`, `recepcionista`
+
+Body:
+```json
+{
+  "username": "prop1",
+  "email": "prop1@mail.com",
+  "password": "Secret123!",
+  "nombreCompleto": "Juan Perez",
+  "numeroIdentificacion": "1020304050",
+  "telefono": "3001234567",
+  "direccion": "Calle 123",
+  "notas": "Prefiere WhatsApp"
+}
+```
+
+Validaciones:
+- `username`: requerido, string, min 3, max 50
+- `email`: requerido, formato email
+- `password`: requerido, string, min 6
+- `nombreCompleto`: requerido, string, max 100
+- `numeroIdentificacion`: requerido, string, max 50, debe ser unico
+- `telefono`: requerido, string, max 50
+- `direccion`: opcional, string, max 100
+- `notas`: opcional, string
+
+Respuestas:
+- `201 Created`: retorna el objeto creado con `id` UUID (y demas campos), **sin** `password`.
+- `409 Conflict`: si `numeroIdentificacion` ya existe (tambien se valida unicidad de `email` y `username`).
+- `400 Bad Request`: validaciones de DTO. Se retorna un unico objeto con detalle por campo:
+  ```json
+  {
+    "message": "Errores de validacion",
+    "errors": {
+      "email": ["email must be an email"],
+      "telefono": ["telefono should not be empty"]
+    }
+  }
+  ```
+
+Notas de seguridad:
+- Password se almacena hasheado (bcrypt) y no se devuelve en respuestas.
+- Adicionalmente, `User.toJSON()` excluye `password` para evitar fugas en respuestas con relaciones.
+
+## HU-B02 - Busqueda de propietarios (GET /propietarios?q=...)
+
+Endpoint:
+- `GET /propietarios?q=<termino>&page=1&limit=20`
+
+Query params:
+- `q` (opcional): termino de busqueda.
+- `page` (opcional): default `1`.
+- `limit` (opcional): default `20`, maximo efectivo `20`.
+
+Comportamiento:
+- Busca simultaneamente en:
+  - `nombreCompleto`
+  - `numeroIdentificacion`
+  - `telefono`
+- Busqueda parcial via `LIKE '%q%'`.
+- Retorna siempre `200` con arreglo (puede ser `[]` si no hay coincidencias).
+
+Importante (case-insensitive):
+- En MySQL la insensibilidad a mayusculas/minusculas depende de la collation de la BD/columnas.
+  En entornos tipicos `utf8mb4_*_ci` es case-insensitive.
+
+Rendimiento / indices:
+- Se agregaron indices para soportar busqueda por:
+  - `users.nombreCompleto`
+  - `users.numeroIdentificacion` (unique)
+  - `users.telefono`
+
+## HU-B03 - Registro de mascota (POST /mascotas)
+
+Endpoint:
+- `POST /mascotas`
+
+Roles permitidos:
+- `admin`, `recepcionista`, `propietario`
+
+Body:
+```json
+{
+  "propietarioId": "<uuid>",
+  "razaId": "<uuid-opcional>",
+  "nombre": "Firulais",
+  "especie": "perro",
+  "edad": 3,
+  "sexo": "macho",
+  "peso": 12.5,
+  "color": "cafe"
+}
+```
+
+Validaciones:
+- Verifica que `propietarioId` exista (si no existe => `404`).
+- `peso` debe ser > 0.
+- `especie` debe estar en la lista controlada:
+  - `perro`, `gato`, `ave`, `otro`
+- `razaId` es opcional (nullable en BD).
+
+Respuestas:
+- `201 Created`: mascota creada con `id` UUID generado automaticamente.
+- `404 Not Found`: propietario no existe.
+- `400 Bad Request`: validaciones del DTO (incluye error por `especie` o `peso`).
+
+## Cambios de modelo / BD
+
+Propietarios:
+- Los propietarios se almacenan en `users` con `rol = propietario`.
+- Se agregaron campos en `users` para soportar HU-B01/HU-B02:
+  - `nombreCompleto`, `numeroIdentificacion`, `direccion`, `telefono`, `notas`
+- Se agregaron indices en `users` para busqueda y unicidad.
+
+Mascotas:
+- `mascotas.id` sigue siendo UUID generado.
+- Se agrego `mascotas.especie` como enum (`perro|gato|ave|otro`), default `otro`.
+- `mascotas.razaId` se dejo nullable para no bloquear registros sin raza.
+

--- a/estado-hu.md
+++ b/estado-hu.md
@@ -1,0 +1,20 @@
+# Estado de Historias de Usuario (HU)
+
+## Completas
+
+- HU-B01
+- HU-B02
+- HU-B03
+
+## Faltantes
+
+- HU-B04
+- HU-B05
+- HU-B06
+- HU-B07
+- HU-B08
+- HU-B09
+- HU-B10
+- HU-B11
+- HU-B12
+- HU-B13

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,32 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import {
+  BadRequestException,
+  ValidationError,
+  ValidationPipe,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
+
+function formatValidationErrors(
+  validationErrors: ValidationError[],
+): Record<string, string[]> {
+  return validationErrors.reduce<Record<string, string[]>>((errors, error) => {
+    const messages = error.constraints ? Object.values(error.constraints) : [];
+    if (messages.length > 0) {
+      errors[error.property] = messages;
+    }
+
+    if (error.children && error.children.length > 0) {
+      const childErrors = formatValidationErrors(error.children);
+      for (const [field, fieldMessages] of Object.entries(childErrors)) {
+        errors[`${error.property}.${field}`] = fieldMessages;
+      }
+    }
+
+    return errors;
+  }, {});
+}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -18,6 +42,11 @@ async function bootstrap() {
       transformOptions: {
         enableImplicitConversion: true,
       },
+      exceptionFactory: (validationErrors: ValidationError[] = []) =>
+        new BadRequestException({
+          message: 'Errores de validacion',
+          errors: formatValidationErrors(validationErrors),
+        }),
     }),
   );
 
@@ -37,4 +66,4 @@ async function bootstrap() {
   console.log(`Application running on http://localhost:${port}`);
   console.log(`Swagger documentation: http://localhost:${port}/docs`);
 }
-bootstrap();
+void bootstrap();

--- a/src/modules/mascota/dto/mascota.dto.ts
+++ b/src/modules/mascota/dto/mascota.dto.ts
@@ -4,10 +4,13 @@ import {
   IsUUID,
   IsOptional,
   IsNumber,
+  IsEnum,
+  IsPositive,
   Min,
   MaxLength,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { EspecieMascota } from '../entities/mascota.entity';
 
 export class CreateMascotaDto {
   @ApiProperty({ example: 'uuid-propietario' })
@@ -15,16 +18,21 @@ export class CreateMascotaDto {
   @IsNotEmpty()
   propietarioId: string;
 
-  @ApiProperty({ example: 'uuid-raza' })
+  @ApiPropertyOptional({ example: 'uuid-raza' })
+  @IsOptional()
   @IsUUID()
-  @IsNotEmpty()
-  razaId: string;
+  razaId?: string;
 
   @ApiProperty({ example: 'Firulais' })
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)
   nombre: string;
+
+  @ApiProperty({ enum: EspecieMascota, example: EspecieMascota.PERRO })
+  @IsEnum(EspecieMascota)
+  @IsNotEmpty()
+  especie: EspecieMascota;
 
   @ApiProperty({ example: 3 })
   @IsNumber()
@@ -41,7 +49,7 @@ export class CreateMascotaDto {
   @ApiProperty({ example: 15.5 })
   @IsNumber()
   @IsNotEmpty()
-  @Min(0)
+  @IsPositive()
   peso: number;
 
   @ApiPropertyOptional({ example: 'Café' })
@@ -70,6 +78,11 @@ export class UpdateMascotaDto {
 
   @ApiPropertyOptional()
   @IsOptional()
+  @IsEnum(EspecieMascota)
+  especie?: EspecieMascota;
+
+  @ApiPropertyOptional()
+  @IsOptional()
   @IsNumber()
   @Min(0)
   edad?: number;
@@ -83,7 +96,7 @@ export class UpdateMascotaDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsNumber()
-  @Min(0)
+  @IsPositive()
   peso?: number;
 
   @ApiPropertyOptional()

--- a/src/modules/mascota/entities/mascota.entity.ts
+++ b/src/modules/mascota/entities/mascota.entity.ts
@@ -8,6 +8,13 @@ import {
 import { User } from '../../user/entities/user.entity';
 import { Raza } from '../../raza/entities/raza.entity';
 
+export enum EspecieMascota {
+  PERRO = 'perro',
+  GATO = 'gato',
+  AVE = 'ave',
+  OTRO = 'otro',
+}
+
 @Entity('mascotas')
 export class Mascota {
   @PrimaryGeneratedColumn('uuid')
@@ -16,11 +23,18 @@ export class Mascota {
   @Column('uuid')
   propietarioId: string;
 
-  @Column('uuid')
-  razaId: string;
+  @Column('uuid', { nullable: true })
+  razaId: string | null;
 
   @Column('varchar', { length: 100 })
   nombre: string;
+
+  @Column({
+    type: 'enum',
+    enum: EspecieMascota,
+    default: EspecieMascota.OTRO,
+  })
+  especie: EspecieMascota;
 
   @Column('int')
   edad: number;
@@ -44,7 +58,7 @@ export class Mascota {
   @JoinColumn({ name: 'propietarioId' })
   propietario: User;
 
-  @ManyToOne(() => Raza)
+  @ManyToOne(() => Raza, { nullable: true })
   @JoinColumn({ name: 'razaId' })
-  raza: Raza;
+  raza: Raza | null;
 }

--- a/src/modules/mascota/mascota.module.ts
+++ b/src/modules/mascota/mascota.module.ts
@@ -3,13 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { MascotaController } from './mascota.controller';
 import { MascotaService } from './mascota.service';
 import { Mascota } from './entities/mascota.entity';
-import { UserModule } from '../user/user.module';
+import { PropietarioModule } from '../propietario/propietario.module';
 import { EspecieModule } from '../especie/especie.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Mascota]),
-    UserModule,
+    PropietarioModule,
     EspecieModule,
   ],
   controllers: [MascotaController],

--- a/src/modules/mascota/mascota.service.ts
+++ b/src/modules/mascota/mascota.service.ts
@@ -3,15 +3,26 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Mascota } from './entities/mascota.entity';
 import { CreateMascotaDto, UpdateMascotaDto } from './dto/mascota.dto';
+import { PropietarioService } from '../propietario/propietario.service';
 
 @Injectable()
 export class MascotaService {
   constructor(
     @InjectRepository(Mascota)
     private readonly mascotaRepository: Repository<Mascota>,
+    private readonly propietarioService: PropietarioService,
   ) {}
 
   async create(createDto: CreateMascotaDto): Promise<Mascota> {
+    const propietarioExists = await this.propietarioService.exists(
+      createDto.propietarioId,
+    );
+    if (!propietarioExists) {
+      throw new NotFoundException(
+        `Propietario con ID ${createDto.propietarioId} no encontrado`,
+      );
+    }
+
     const mascota = this.mascotaRepository.create(createDto);
     return await this.mascotaRepository.save(mascota);
   }
@@ -43,6 +54,17 @@ export class MascotaService {
 
   async update(id: string, updateDto: UpdateMascotaDto): Promise<Mascota> {
     const mascota = await this.findOne(id);
+    if (updateDto.propietarioId) {
+      const propietarioExists = await this.propietarioService.exists(
+        updateDto.propietarioId,
+      );
+      if (!propietarioExists) {
+        throw new NotFoundException(
+          `Propietario con ID ${updateDto.propietarioId} no encontrado`,
+        );
+      }
+    }
+
     Object.assign(mascota, updateDto);
     return await this.mascotaRepository.save(mascota);
   }

--- a/src/modules/propietario/dto/propietario.dto.ts
+++ b/src/modules/propietario/dto/propietario.dto.ts
@@ -1,7 +1,9 @@
 import {
+  IsEmail,
   IsString,
   IsNotEmpty,
   IsOptional,
+  MinLength,
   MaxLength,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -10,22 +12,32 @@ export class CreatePropietarioDto {
   @ApiProperty({ example: 'juan_perez' })
   @IsString()
   @IsNotEmpty()
+  @MinLength(3)
+  @MaxLength(50)
   username: string;
 
   @ApiProperty({ example: 'juan@example.com' })
-  @IsString()
   @IsNotEmpty()
+  @IsEmail()
   email: string;
 
   @ApiProperty({ example: 'password123' })
   @IsString()
   @IsNotEmpty()
+  @MinLength(6)
   password: string;
 
-  @ApiPropertyOptional({ example: 'Juan Pérez' })
-  @IsOptional()
+  @ApiProperty({ example: 'Juan Perez' })
   @IsString()
-  nombreCompleto?: string;
+  @IsNotEmpty()
+  @MaxLength(100)
+  nombreCompleto: string;
+
+  @ApiProperty({ example: '1020304050' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  numeroIdentificacion: string;
 
   @ApiPropertyOptional({ example: 'Calle 123' })
   @IsOptional()
@@ -33,18 +45,30 @@ export class CreatePropietarioDto {
   @MaxLength(100)
   direccion?: string;
 
-  @ApiPropertyOptional({ example: '1234567890' })
+  @ApiProperty({ example: '1234567890' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  telefono: string;
+
+  @ApiPropertyOptional({ example: 'Prefiere contacto por WhatsApp' })
   @IsOptional()
   @IsString()
-  @MaxLength(50)
-  telefono?: string;
+  notas?: string;
 }
 
 export class UpdatePropietarioDto {
   @ApiPropertyOptional()
   @IsOptional()
   @IsString()
+  @MaxLength(100)
   nombreCompleto?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MaxLength(50)
+  numeroIdentificacion?: string;
 
   @ApiPropertyOptional()
   @IsOptional()

--- a/src/modules/propietario/entities/propietario.entity.ts
+++ b/src/modules/propietario/entities/propietario.entity.ts
@@ -1,14 +1,5 @@
-import { Entity, Column } from 'typeorm';
+import { Entity } from 'typeorm';
 import { User } from '../../user/entities/user.entity';
 
 @Entity('propietarios')
-export class Propietario extends User {
-  @Column('varchar', { length: 100, nullable: true })
-  direccion: string;
-
-  @Column('varchar', { length: 50, nullable: true })
-  telefono: string;
-
-  @Column('text', { nullable: true })
-  notas: string;
-}
+export class Propietario extends User {}

--- a/src/modules/propietario/propietario.controller.ts
+++ b/src/modules/propietario/propietario.controller.ts
@@ -1,18 +1,24 @@
 import {
+  Body,
   Controller,
   Get,
   Param,
+  ParseIntPipe,
   ParseUUIDPipe,
+  Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
-  ApiTags,
-  ApiOperation,
-  ApiResponse,
   ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
 } from '@nestjs/swagger';
-import { UserService } from '../user/user.service';
-import { User } from '../user/entities/user.entity';
+import { PropietarioResponse, PropietarioService } from './propietario.service';
+import { CreatePropietarioDto } from './dto/propietario.dto';
+import { Propietario } from './entities/propietario.entity';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
@@ -24,17 +30,42 @@ import { RoleType } from '../rol/entities/rol.entity';
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Roles(RoleType.ADMIN, RoleType.RECEPCIONISTA)
 export class PropietarioController {
-  constructor(private readonly userService: UserService) {}
+  constructor(private readonly propietarioService: PropietarioService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Crear un nuevo propietario' })
+  @ApiResponse({
+    status: 201,
+    description: 'Propietario creado exitosamente',
+    type: Propietario,
+  })
+  @ApiResponse({ status: 400, description: 'Datos invalidos' })
+  @ApiResponse({
+    status: 409,
+    description: 'Numero de identificacion, email o usuario duplicado',
+  })
+  create(
+    @Body() createDto: CreatePropietarioDto,
+  ): Promise<PropietarioResponse> {
+    return this.propietarioService.create(createDto);
+  }
 
   @Get()
-  @ApiOperation({ summary: 'Obtener todos los propietarios' })
+  @ApiOperation({ summary: 'Buscar propietarios' })
+  @ApiQuery({ name: 'q', required: false })
+  @ApiQuery({ name: 'page', required: false, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, example: 20 })
   @ApiResponse({
     status: 200,
     description: 'Propietarios obtenidos exitosamente',
-    type: [User],
+    type: [Propietario],
   })
-  findAll(): Promise<User[]> {
-    return this.userService.findByRol(RoleType.PROPIETARIO);
+  findAll(
+    @Query('q') q?: string,
+    @Query('page', new ParseIntPipe({ optional: true })) page = 1,
+    @Query('limit', new ParseIntPipe({ optional: true })) limit = 20,
+  ): Promise<PropietarioResponse[]> {
+    return this.propietarioService.search(q, page, limit);
   }
 
   @Get(':id')
@@ -42,10 +73,12 @@ export class PropietarioController {
   @ApiResponse({
     status: 200,
     description: 'Propietario obtenido exitosamente',
-    type: User,
+    type: Propietario,
   })
   @ApiResponse({ status: 404, description: 'Propietario no encontrado' })
-  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<User> {
-    return this.userService.findOne(id);
+  findOne(
+    @Param('id', ParseUUIDPipe) id: string,
+  ): Promise<PropietarioResponse> {
+    return this.propietarioService.findOne(id);
   }
 }

--- a/src/modules/propietario/propietario.module.ts
+++ b/src/modules/propietario/propietario.module.ts
@@ -1,14 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PropietarioController } from './propietario.controller';
-import { Propietario } from './entities/propietario.entity';
-import { UserModule } from '../user/user.module';
+import { PropietarioService } from './propietario.service';
+import { RolModule } from '../rol/rol.module';
+import { User } from '../user/entities/user.entity';
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Propietario]),
-    UserModule,
-  ],
+  imports: [TypeOrmModule.forFeature([User]), RolModule],
   controllers: [PropietarioController],
+  providers: [PropietarioService],
+  exports: [PropietarioService],
 })
 export class PropietarioModule {}

--- a/src/modules/propietario/propietario.service.ts
+++ b/src/modules/propietario/propietario.service.ts
@@ -1,0 +1,131 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { CreatePropietarioDto } from './dto/propietario.dto';
+import { RolService } from '../rol/rol.service';
+import { RoleType } from '../rol/entities/rol.entity';
+import { User, UserStatus } from '../user/entities/user.entity';
+
+export type PropietarioResponse = Omit<User, 'password'>;
+
+@Injectable()
+export class PropietarioService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly rolService: RolService,
+  ) {}
+
+  async create(createDto: CreatePropietarioDto): Promise<PropietarioResponse> {
+    await this.ensureUniqueFields(createDto);
+
+    const rol = await this.rolService.findByName(RoleType.PROPIETARIO);
+    if (!rol) {
+      throw new BadRequestException('El rol propietario no existe');
+    }
+
+    const hashedPassword = await bcrypt.hash(createDto.password, 10);
+    const propietario = this.userRepository.create({
+      ...createDto,
+      password: hashedPassword,
+      rol,
+      status: UserStatus.ACTIVO,
+      isActive: true,
+    });
+
+    const saved = await this.userRepository.save(propietario);
+    return this.toResponse(saved);
+  }
+
+  async search(
+    q?: string,
+    page = 1,
+    limit = 20,
+  ): Promise<PropietarioResponse[]> {
+    const safePage = Number.isFinite(page) && page > 0 ? page : 1;
+    const safeLimit = Math.min(
+      Math.max(Number.isFinite(limit) && limit > 0 ? limit : 20, 1),
+      20,
+    );
+
+    const query = this.userRepository
+      .createQueryBuilder('propietario')
+      .innerJoinAndSelect('propietario.rol', 'rol')
+      .where('rol.name = :rol', { rol: RoleType.PROPIETARIO })
+      .orderBy('propietario.createdAt', 'DESC')
+      .skip((safePage - 1) * safeLimit)
+      .take(safeLimit);
+
+    const term = q?.trim();
+    if (term) {
+      query.andWhere(
+        [
+          'propietario.nombreCompleto LIKE :term',
+          'propietario.numeroIdentificacion LIKE :term',
+          'propietario.telefono LIKE :term',
+        ].join(' OR '),
+        { term: `%${term}%` },
+      );
+    }
+
+    const propietarios = await query.getMany();
+    return propietarios.map((propietario) => this.toResponse(propietario));
+  }
+
+  async findOne(id: string): Promise<PropietarioResponse> {
+    const propietario = await this.userRepository.findOne({
+      where: { id, rol: { name: RoleType.PROPIETARIO } },
+      relations: ['rol'],
+    });
+    if (!propietario) {
+      throw new NotFoundException(`Propietario con ID ${id} no encontrado`);
+    }
+
+    return this.toResponse(propietario);
+  }
+
+  async exists(id: string): Promise<boolean> {
+    return await this.userRepository.exists({
+      where: { id, rol: { name: RoleType.PROPIETARIO } },
+    });
+  }
+
+  private async ensureUniqueFields(
+    createDto: CreatePropietarioDto,
+  ): Promise<void> {
+    const existingIdentification = await this.userRepository.findOne({
+      where: { numeroIdentificacion: createDto.numeroIdentificacion },
+    });
+    if (existingIdentification) {
+      throw new ConflictException(
+        'El numero de identificacion ya esta registrado',
+      );
+    }
+
+    const existingEmail = await this.userRepository.findOne({
+      where: { email: createDto.email },
+    });
+    if (existingEmail) {
+      throw new ConflictException('El email ya esta registrado');
+    }
+
+    const existingUsername = await this.userRepository.findOne({
+      where: { username: createDto.username },
+    });
+    if (existingUsername) {
+      throw new ConflictException('El nombre de usuario ya esta en uso');
+    }
+  }
+
+  private toResponse(propietario: User): PropietarioResponse {
+    const { password, ...response } = propietario;
+    void password;
+    return response as PropietarioResponse;
+  }
+}

--- a/src/modules/user/entities/user.entity.ts
+++ b/src/modules/user/entities/user.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   JoinColumn,
   Unique,
+  Index,
 } from 'typeorm';
 import { Rol } from '../../rol/entities/rol.entity';
 
@@ -17,6 +18,11 @@ export enum UserStatus {
 @Entity('users')
 @Unique(['email'])
 @Unique(['username'])
+@Index('IDX_users_nombre_completo', ['nombreCompleto'])
+@Index('IDX_users_numero_identificacion', ['numeroIdentificacion'], {
+  unique: true,
+})
+@Index('IDX_users_telefono', ['telefono'])
 export class User {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -29,6 +35,21 @@ export class User {
 
   @Column('varchar', { length: 255 })
   password: string;
+
+  @Column('varchar', { length: 100, nullable: true })
+  nombreCompleto: string | null;
+
+  @Column('varchar', { length: 50, nullable: true })
+  numeroIdentificacion: string | null;
+
+  @Column('varchar', { length: 100, nullable: true })
+  direccion: string | null;
+
+  @Column('varchar', { length: 50, nullable: true })
+  telefono: string | null;
+
+  @Column('text', { nullable: true })
+  notas: string | null;
 
   @Column({
     type: 'enum',
@@ -52,4 +73,10 @@ export class User {
   @ManyToOne(() => Rol, { eager: true })
   @JoinColumn({ name: 'rol_id' })
   rol: Rol;
+
+  toJSON() {
+    const { password, ...user } = this;
+    void password;
+    return user;
+  }
 }


### PR DESCRIPTION
HU-B01 (POST /propietarios)
- Crea propietarios como usuarios con rol 'propietario' (requiere JWT, roles: admin/recepcionista).
- Valida campos obligatorios, formato de email y unicidad de numeroIdentificacion (409 Conflict).
- Hash de password (bcrypt) y respuesta sin datos sensibles (password no se retorna).

HU-B02 (GET /propietarios?q=...)
- Busqueda simultanea en nombreCompleto, numeroIdentificacion y telefono.
- Busqueda parcial via LIKE y paginacion con limite maximo 20 (page/limit).
- Responde 200 con [] si no hay coincidencias.
- Indices en users para soportar rendimiento: nombreCompleto, telefono, numeroIdentificacion (unique).

HU-B03 (POST /mascotas)
- Verifica existencia de propietario antes de crear mascota (404 si no existe).
- Peso validado como > 0.
- Especie controlada (enum): perro, gato, ave, otro (default 'otro').
- razaId ahora es opcional/nullable.

Cross-cutting
- Formato unificado de errores de validacion (400) en un solo objeto con detalle por campo (src/main.ts).
- Evita exponer password por serializacion agregando User.toJSON() sin password.

Documentacion
- docs/HU-B01-B03-propietarios-mascotas.md incluye contratos, ejemplos y notas para frontend/DB.
- estado-hu.md actualizado marcando HU-B01/HU-B02/HU-B03 como completas.